### PR TITLE
Add missing gradle_config for SDK 15.0 sample builds

### DIFF
--- a/gradle_config/setBuildVersions.gradle
+++ b/gradle_config/setBuildVersions.gradle
@@ -1,0 +1,11 @@
+// we apply those configurations to build.gradle files for all-apps-android
+// to override it you can specify the value directly in build.gradle for each project
+
+android {
+    compileSdk 36
+
+    defaultConfig {
+        minSdk 31
+        targetSdk 36
+    }
+}


### PR DESCRIPTION
## Summary
- Add `gradle_config/setBuildVersions.gradle` that sample `app/build.gradle` files already apply
- Fixes GitHub external validation failures (`Could not read script .../gradle_config/setBuildVersions.gradle`)

## Test plan
- [ ] Confirm file matches GitLab mirror content
- [ ] After merge, re-run `Test.Android.PublicSamples.Manual/rel-15_0` with `ACTION=Validate external apps - GitHub`, `SDK_VERSION=15.0.8513.67`, `NOC=stage11`